### PR TITLE
TestHelper user creation bug and typo fix

### DIFF
--- a/modules/TestHelpers/client/user.js
+++ b/modules/TestHelpers/client/user.js
@@ -2,7 +2,7 @@ const ACCOUNT_USERNAME = 'test-user';
 const ACCOUNT_PASSWORD = 'test-password'
 
 export function loginToTestAccount(done) {
-  if (Meteor.users.find({ username: ACCOUNT_USERNAME }).count() === 0) {
+  if (Meteor.users.find({ username: ACCOUNT_USERNAME }).count() !== 0) {
     Meteor.loginWithPassword(ACCOUNT_USERNAME, ACCOUNT_PASSWORD, (err) => {
       expect(err).not.toBeDefined();
       done();

--- a/modules/TodoApp/server/__tests__/integration/Todo-test.js
+++ b/modules/TodoApp/server/__tests__/integration/Todo-test.js
@@ -1,5 +1,5 @@
 describe('Todo', () => {
-  it('should write unit tests on server-side code', () => {
+  it('should write integration tests on server-side code', () => {
     expect(true).toEqual(true);
   });
 });


### PR DESCRIPTION
If the user is found in the `Meteor.users` collection (meaning the count is not 0), then log in. Otherwise create user.